### PR TITLE
Harden long-running Modal evaluations

### DIFF
--- a/external/harbor/src/harbor/agents/installed/claude_code.py
+++ b/external/harbor/src/harbor/agents/installed/claude_code.py
@@ -879,6 +879,13 @@ class ClaudeCode(BaseInstalledAgent):
             or os.environ.get("ANTHROPIC_AUTH_TOKEN")
             or "",
             "ANTHROPIC_BASE_URL": os.environ.get("ANTHROPIC_BASE_URL", None),
+            "ANTHROPIC_CUSTOM_HEADERS": os.environ.get(
+                "ANTHROPIC_CUSTOM_HEADERS", None
+            ),
+            "ENABLE_TOOL_SEARCH": os.environ.get("ENABLE_TOOL_SEARCH", None),
+            "CLAUDE_CODE_EFFORT_LEVEL": os.environ.get(
+                "CLAUDE_CODE_EFFORT_LEVEL", None
+            ),
             "CLAUDE_CODE_OAUTH_TOKEN": os.environ.get("CLAUDE_CODE_OAUTH_TOKEN", ""),
             "CLAUDE_CODE_MAX_OUTPUT_TOKENS": os.environ.get(
                 "CLAUDE_CODE_MAX_OUTPUT_TOKENS", "128000"

--- a/external/harbor/src/harbor/environments/modal.py
+++ b/external/harbor/src/harbor/environments/modal.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path, PurePosixPath
+from uuid import uuid4
 
 from modal import App, Image, Sandbox, Secret, Volume
 from tenacity import retry, stop_after_attempt, wait_exponential
@@ -8,6 +9,14 @@ from harbor.environments.base import BaseEnvironment, ExecResult
 from harbor.models.environment_type import EnvironmentType
 from harbor.models.task.config import EnvironmentConfig
 from harbor.models.trial.paths import EnvironmentPaths, TrialPaths
+
+
+# Modal caps the combined size of Sandbox.exec command arguments at 65,536
+# bytes. Keep enough headroom for the shell argv itself and stage larger shell
+# programs through the sandbox filesystem instead. SWE-Together contains a
+# legitimate 78 KiB task instruction, so this is not merely a defensive edge
+# case.
+_MAX_INLINE_COMMAND_BYTES = 60_000
 
 
 class ModalEnvironment(BaseEnvironment):
@@ -160,7 +169,7 @@ class ModalEnvironment(BaseEnvironment):
             # TODO(alexgshaw): use __harbor__ once Modal removes this error: The
             # selected app is locked - probably due to a concurrent modification taking
             # place.
-            name="__harbor__",
+            name=os.environ.get("HARBOR_MODAL_APP_NAME", "__harbor__"),
             # name=self.session_id,
             create_if_missing=True,
         )
@@ -368,10 +377,21 @@ class ModalEnvironment(BaseEnvironment):
         if not self._sandbox:
             raise RuntimeError("Sandbox not found. Please start the environment first.")
 
+        exec_args = ("bash", "-c", command)
+        command_bytes = command.encode("utf-8")
+        if len(command_bytes) > _MAX_INLINE_COMMAND_BYTES:
+            script_path = f"/tmp/harbor-exec-{uuid4().hex}.sh"
+            async with await self._sandbox.open.aio(script_path, "wb") as file_handle:
+                await file_handle.write.aio(command_bytes)
+            exec_args = ("bash", script_path)
+            self.logger.debug(
+                "Staged %d-byte command at %s to stay below Modal ARG_MAX",
+                len(command_bytes),
+                script_path,
+            )
+
         process = await self._sandbox.exec.aio(
-            "bash",
-            "-c",
-            command,
+            *exec_args,
             workdir=cwd,
             secrets=[Secret.from_dict(env)] if env else [],  # type: ignore
             timeout=timeout_sec,

--- a/external/harbor/src/harbor/models/trial/config.py
+++ b/external/harbor/src/harbor/models/trial/config.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Any, Literal, NotRequired, TypedDict
 from uuid import UUID
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_serializer, model_validator
 from shortuuid import ShortUUID
 
 from harbor.models.agent.name import AgentName
@@ -37,6 +37,50 @@ class ArtifactConfig(BaseModel):
     destination: str | None = None
 
 
+_REDACTED = "[REDACTED]"
+_SENSITIVE_KEY_SUFFIXES = (
+    "_API_KEY",
+    "_AUTH_TOKEN",
+    "_ACCESS_TOKEN",
+    "_SECRET",
+    "_PASSWORD",
+    "_CREDENTIALS",
+)
+_SENSITIVE_KEYS = {
+    "API_KEY",
+    "AUTHORIZATION",
+    "CUSTOM_HEADERS",
+    "ANTHROPIC_CUSTOM_HEADERS",
+    "USER_API_KEY",
+}
+
+
+def _redact_config_secrets(value: Any) -> Any:
+    """Return a JSON-safe copy with credential-bearing values removed.
+
+    Trial configs must retain real credentials in memory so agents can run,
+    but config.json/result.json are durable artifacts and must never persist
+    them. Key-based recursive redaction covers agent env plus nested kwargs
+    without hiding non-secret token controls such as max_output_tokens.
+    """
+    if isinstance(value, dict):
+        redacted: dict[Any, Any] = {}
+        for key, nested in value.items():
+            normalized = str(key).upper()
+            if normalized in _SENSITIVE_KEYS or normalized.endswith(
+                _SENSITIVE_KEY_SUFFIXES
+            ):
+                redacted[key] = _REDACTED
+            else:
+                redacted[key] = _redact_config_secrets(nested)
+        return redacted
+    if isinstance(value, list):
+        return [_redact_config_secrets(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_redact_config_secrets(item) for item in value)
+    return value
+
+
 class AgentConfig(BaseModel):
     name: str | None = None
     import_path: str | None = None
@@ -46,6 +90,10 @@ class AgentConfig(BaseModel):
     max_timeout_sec: float | None = None
     kwargs: dict[str, Any] = Field(default_factory=dict)
     env: dict[str, str] = Field(default_factory=dict)
+
+    @field_serializer("kwargs", "env", when_used="json")
+    def redact_serialized_secrets(self, value: dict[str, Any]) -> dict[str, Any]:
+        return _redact_config_secrets(value)
 
     @model_validator(mode="after")
     def set_default_name(self):
@@ -67,6 +115,10 @@ class EnvironmentConfig(BaseModel):
     mounts_json: list[ServiceVolumeConfig] | None = None
     env: dict[str, str] = Field(default_factory=dict)
     kwargs: dict[str, Any] = Field(default_factory=dict)
+
+    @field_serializer("env", "kwargs", when_used="json")
+    def redact_serialized_secrets(self, value: dict[str, Any]) -> dict[str, Any]:
+        return _redact_config_secrets(value)
 
     @model_validator(mode="after")
     def set_default_type(self):

--- a/src/eval_infra_sentinel.py
+++ b/src/eval_infra_sentinel.py
@@ -28,7 +28,7 @@ from pathlib import Path
 from typing import Any
 
 SIDECAR_NAME = "trial_infra.json"
-SIDECAR_VERSION = 1
+SIDECAR_VERSION = 3
 
 # Patch sizes <= this are treated as "empty" (header-only stubs of the form
 # `=== /workspace/repo (cumulative vs harbor-base) ===`). The longest such
@@ -95,6 +95,8 @@ class TrialSignals:
     result_subtypes: list[str] = field(default_factory=list)
     transcript_present_but_empty: bool = False
     empty_transcript_names: list[str] = field(default_factory=list)
+    exception_type: str = ""
+    exception_message: str = ""
 
 
 @dataclass
@@ -256,6 +258,14 @@ def collect_signals(trial_dir: Path) -> TrialSignals:
     if present and all(_is_empty_transcript(p) for p in present):
         sig.transcript_present_but_empty = True
         sig.empty_transcript_names = [p.name for p in present]
+    try:
+        result = json.loads((trial_dir / "result.json").read_text(errors="ignore"))
+        exception = result.get("exception_info") or {}
+        if isinstance(exception, dict):
+            sig.exception_type = str(exception.get("exception_type") or "")
+            sig.exception_message = str(exception.get("exception_message") or "")
+    except (OSError, json.JSONDecodeError):
+        pass
     return sig
 
 
@@ -386,6 +396,54 @@ def _detect_no_agent_progress(sig: TrialSignals) -> tuple[bool, str, dict[str, A
     }
 
 
+def _detect_modal_control_plane(sig: TrialSignals) -> tuple[bool, str, dict[str, Any]]:
+    """Detect retryable Modal SDK/control-plane failures recorded by Harbor."""
+    dns_failure = (
+        sig.exception_type == "ConnectionError"
+        and "nodename nor servname provided" in sig.exception_message
+    )
+    stream_failure = (
+        sig.exception_type == "InternalError"
+        and "Failed to read exec stdio stream" in sig.exception_message
+    )
+    sandbox_not_found = (
+        sig.exception_type == "NotFoundError"
+        and "Modal Sandbox with container ID" in sig.exception_message
+        and "has already shut down" in sig.exception_message
+    )
+    if not (dns_failure or stream_failure or sandbox_not_found):
+        return False, "", {}
+    if dns_failure:
+        kind = "DNS/control-plane lookup"
+        failure_kind = "dns"
+    elif stream_failure:
+        kind = "exec stdio stream"
+        failure_kind = "exec_stream"
+    else:
+        kind = "sandbox disappearance"
+        failure_kind = "sandbox_not_found"
+    return True, f"Modal {kind} failure interrupted the trial", {
+        "exception_type": sig.exception_type,
+        "failure_kind": failure_kind,
+    }
+
+
+def _detect_harness_command_arg_limit(
+    sig: TrialSignals,
+) -> tuple[bool, str, dict[str, Any]]:
+    """Detect Modal's command-argument limit rejecting a valid large prompt."""
+    matched = (
+        sig.exception_type == "InvalidError"
+        and "Total length of CMD arguments cannot exceed 65536 bytes" in sig.exception_message
+    )
+    if not matched:
+        return False, "", {}
+    return True, "Harness embedded a command larger than Modal ARG_MAX", {
+        "exception_type": sig.exception_type,
+        "failure_kind": "command_arg_limit",
+    }
+
+
 _OPENCODE_PROVIDER_HINTS = (
     "exceeded your current quota", "insufficient_quota", "provider_unavailable",
     "resource_exhausted", "rate limit", "rate_limit", "overloaded",
@@ -443,6 +501,8 @@ def _detect_opencode_backend_error(sig: TrialSignals) -> tuple[bool, str, dict[s
 # "no_agent_progress" detector runs last so a real provider error gets the
 # precise reason in its sidecar instead of the generic one.
 DETECTORS: list[tuple[str, Any]] = [
+    ("modal_control_plane", _detect_modal_control_plane),
+    ("harness_command_arg_limit", _detect_harness_command_arg_limit),
     ("empty_transcript", _detect_empty_transcript),
     ("provider_402_balance", _detect_provider_402_balance),
     ("provider_429_quota", _detect_provider_429_quota),
@@ -488,6 +548,26 @@ def classify_trial(trial_dir: Path, strict: bool = False) -> InfraVerdict:
         "edit_tool_calls": sig.edit_tool_calls,
         "api_retry_count": sig.api_retry_count,
     }
+    modal_matched, modal_detail, modal_evidence = _detect_modal_control_plane(sig)
+    if modal_matched:
+        return InfraVerdict(
+            status="infra_failed",
+            reason="modal_control_plane",
+            detail=modal_detail,
+            signals=["modal_control_plane"],
+            evidence={**modal_evidence, **base_evidence},
+        )
+    arg_limit_matched, arg_limit_detail, arg_limit_evidence = (
+        _detect_harness_command_arg_limit(sig)
+    )
+    if arg_limit_matched:
+        return InfraVerdict(
+            status="infra_failed",
+            reason="harness_command_arg_limit",
+            detail=arg_limit_detail,
+            signals=["harness_command_arg_limit"],
+            evidence={**arg_limit_evidence, **base_evidence},
+        )
     if has_real_patch and not strict:
         return InfraVerdict(
             status="ok", reason="", detail="",

--- a/src/run_eval.py
+++ b/src/run_eval.py
@@ -430,7 +430,9 @@ def build_trial_config(
         # install pulls LATEST (currently 2.1.119), which has a client-side
         # model-name validator that rejects non-Anthropic names like kimi-k2.6
         # before any API call is made.
-        "version": "2.1.108",
+        "version": os.environ.get(
+            "SWE_TOGETHER_CLAUDE_CODE_VERSION", "2.1.108"
+        ),
     }
 
     # Model name sent to Harbor.self.model_name governs BOTH the ANTHROPIC_MODEL
@@ -441,6 +443,10 @@ def build_trial_config(
     # (LiteLLM proxy OR direct Anthropic-compatible endpoint), lie to Harbor
     # and say "claude-sonnet-4-6" — the backend maps it to the real model.
     harbor_model = action_model
+    if action_model.startswith("anthropic/"):
+        # Claude Code expects its native model id even when the request is sent
+        # through a custom Anthropic-compatible base URL such as WorkWeave.
+        harbor_model = action_model.split("/", 1)[1]
     if agent_env.get("LITELLM_PROXY_MODEL"):
         harbor_model = "claude-sonnet-4-6"
     elif agent_env.get("ANTHROPIC_BASE_URL") in (_ARK_BASE_URL, _MINIMAX_BASE_URL, _GLMD_BASE_URL):
@@ -559,6 +565,14 @@ def build_trial_config(
     env_config = EnvironmentConfig(delete=True, force_build=force_build)
     if env_type:
         env_config.type = EnvironmentType(env_type)
+    if env_type == "modal":
+        # Orphaned sandboxes must self-terminate even if the coordinator loses
+        # its Modal control-plane connection during cleanup. The agent gets up
+        # to 80 minutes; two hours leaves room for setup and verification.
+        env_config.kwargs.update(
+            sandbox_timeout_secs=7200,
+            sandbox_idle_timeout_secs=900,
+        )
 
     return TrialConfig(
         task=TaskConfig(path=task_dir),
@@ -640,6 +654,25 @@ def _emit_infra_sidecars(trials_dir: Path) -> dict[str, int]:
         if verdict.status == "infra_failed":
             counts[verdict.reason] = counts.get(verdict.reason, 0) + 1
     return counts
+
+
+def _build_retry_config() -> RetryConfig:
+    """Retry transient provider and sandbox-control-plane interruptions."""
+    return RetryConfig(
+        max_retries=5,
+        include_exceptions=[
+            "RateLimitException",  # E2B 429 — sandbox cap or template-build cap
+            "TimeoutException",    # sandbox lost mid-run (gRPC unavailable)
+            "ConnectTimeout",      # httpcore network blip during sandbox create
+            "ConnectionError",     # Modal DNS/control-plane lookup failure
+            "InternalError",       # Modal exec stdio stream interruption
+            "NotFoundError",       # Modal sandbox disappeared mid-trial
+            "AddTestsDirError",    # transient docker upload_dir failure
+        ],
+        min_wait_sec=60.0,
+        max_wait_sec=300.0,
+        wait_multiplier=2.0,
+    )
 
 
 def _sanitize_and_upload(trials_dir: Path):
@@ -733,6 +766,8 @@ async def main():
                              "thinking.budget_tokens low=1024/med=4096/high=16384). "
                              "DeepSeek ignores this knob.")
     parser.add_argument("--trials-dir", default=None, help="Trials directory (default: trials/)")
+    parser.add_argument("--pipeline-logs-dir", default=None,
+                        help="Manifest/summary directory (default: <repo>/pipeline_logs)")
     parser.add_argument("--tasks", default=None, help="Comma-separated task names or globs")
     parser.add_argument("--skip-existing", action="store_true", help="Skip tasks with existing results")
     parser.add_argument("--dry-run", action="store_true")
@@ -813,9 +848,21 @@ async def main():
 
     # Reproducibility metadata
     import subprocess as _sp
-    git_sha = _sp.run(["git", "rev-parse", "HEAD"], capture_output=True, text=True, cwd=str(REPO_ROOT)).stdout.strip()
-    git_tag = _sp.run(["git", "describe", "--tags", "--exact-match"], capture_output=True, text=True, cwd=str(REPO_ROOT)).stdout.strip() or "untagged"
-    git_dirty = "clean" if _sp.run(["git", "diff", "--quiet"], cwd=str(REPO_ROOT)).returncode == 0 else "dirty"
+    git_sha = os.environ.get("SWE_TOGETHER_SOURCE_SHA", "") or _sp.run(
+        ["git", "rev-parse", "HEAD"], capture_output=True, text=True,
+        cwd=str(REPO_ROOT),
+    ).stdout.strip()
+    git_tag = os.environ.get("SWE_TOGETHER_SOURCE_TAG", "") or _sp.run(
+        ["git", "describe", "--tags", "--exact-match"], capture_output=True,
+        text=True, cwd=str(REPO_ROOT),
+    ).stdout.strip() or "untagged"
+    git_dirty = os.environ.get("SWE_TOGETHER_SOURCE_DIRTY", "")
+    if not git_dirty:
+        dirty_check = _sp.run(
+            ["git", "diff", "--quiet"], capture_output=True,
+            cwd=str(REPO_ROOT),
+        )
+        git_dirty = "clean" if dirty_check.returncode == 0 else "dirty"
     from datetime import datetime
     started_at = datetime.now().isoformat()
 
@@ -851,7 +898,8 @@ async def main():
         "task_count": len(task_names),
         "tasks": task_names,
     }
-    manifest_dir = REPO_ROOT / "pipeline_logs"
+    manifest_dir = (Path(args.pipeline_logs_dir) if args.pipeline_logs_dir
+                    else REPO_ROOT / "pipeline_logs")
     manifest_dir.mkdir(exist_ok=True)
     manifest_path = manifest_dir / f"eval-{args.tag}-manifest.json"
     manifest_path.write_text(json.dumps(manifest, indent=2))
@@ -900,18 +948,7 @@ async def main():
     # equality, not isinstance). So we list the *concrete* subclasses we want to
     # retry, not "SandboxException" (which would only match the literal alias-404
     # case where retry can never succeed).
-    retry_config = RetryConfig(
-        max_retries=5,
-        include_exceptions=[
-            "RateLimitException",  # E2B 429 — sandbox cap or template-build cap
-            "TimeoutException",    # sandbox lost mid-run (gRPC unavailable)
-            "ConnectTimeout",      # httpcore network blip during sandbox create
-            "AddTestsDirError",    # transient docker upload_dir failure
-        ],
-        min_wait_sec=60.0,
-        max_wait_sec=300.0,
-        wait_multiplier=2.0,
-    )
+    retry_config = _build_retry_config()
     orchestrator = LocalOrchestrator(
         trial_configs=trial_configs,
         n_concurrent_trials=args.workers,
@@ -987,7 +1024,8 @@ async def main():
         print(f"{s['task']:<40} {reward:>7} {s['interventions']:>5} {actions_str:<20} {status:<8}")
 
     # Write summary JSON
-    summary_dir = REPO_ROOT / "pipeline_logs"
+    summary_dir = (Path(args.pipeline_logs_dir) if args.pipeline_logs_dir
+                   else REPO_ROOT / "pipeline_logs")
     summary_dir.mkdir(exist_ok=True)
     summary_path = summary_dir / f"eval-{args.tag}-summary.json"
     summary_data = {

--- a/tests/test_eval_hardening.py
+++ b/tests/test_eval_hardening.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from pathlib import Path
+
+from eval_infra_sentinel import SIDECAR_VERSION, classify_or_load, classify_trial
+from harbor.models.trial.config import AgentConfig, TaskConfig, TrialConfig
+from harbor.environments.modal import ModalEnvironment, _MAX_INLINE_COMMAND_BYTES
+from run_eval import _build_retry_config, build_trial_config
+
+
+def _write_modal_failure(trial: Path, exception_type: str, message: str) -> None:
+    (trial / "agent").mkdir(parents=True)
+    (trial / "agent" / "final.patch").write_text("diff --git a/a b/a\n" + "x" * 300)
+    (trial / "result.json").write_text(
+        json.dumps(
+            {
+                "exception_info": {
+                    "exception_type": exception_type,
+                    "exception_message": message,
+                }
+            }
+        )
+    )
+
+
+def test_trial_config_redacts_secrets_only_when_serialized(tmp_path: Path) -> None:
+    agent = AgentConfig(
+        kwargs={"user_api_key": "gemini-secret", "max_output_tokens": 8192},
+        env={
+            "ANTHROPIC_API_KEY": "anthropic-secret",
+            "ANTHROPIC_CUSTOM_HEADERS": "X-Weave-Router-Key: router-secret",
+            "CLAUDE_CODE_EFFORT_LEVEL": "high",
+        },
+    )
+    config = TrialConfig(task=TaskConfig(path=tmp_path), agent=agent)
+
+    assert config.agent.env["ANTHROPIC_API_KEY"] == "anthropic-secret"
+    serialized = json.loads(config.model_dump_json())
+    assert serialized["agent"]["kwargs"]["user_api_key"] == "[REDACTED]"
+    assert serialized["agent"]["kwargs"]["max_output_tokens"] == 8192
+    assert serialized["agent"]["env"]["ANTHROPIC_API_KEY"] == "[REDACTED]"
+    assert serialized["agent"]["env"]["ANTHROPIC_CUSTOM_HEADERS"] == "[REDACTED]"
+    assert serialized["agent"]["env"]["CLAUDE_CODE_EFFORT_LEVEL"] == "high"
+    assert "anthropic-secret" not in config.model_dump_json()
+    assert "gemini-secret" not in config.model_dump_json()
+    assert "router-secret" not in config.model_dump_json()
+
+
+def test_modal_dns_failure_is_infra_even_with_real_patch(tmp_path: Path) -> None:
+    _write_modal_failure(
+        tmp_path,
+        "ConnectionError",
+        "[Errno 8] nodename nor servname provided, or not known",
+    )
+    verdict = classify_trial(tmp_path)
+    assert verdict.status == "infra_failed"
+    assert verdict.reason == "modal_control_plane"
+    assert verdict.evidence["failure_kind"] == "dns"
+
+
+def test_modal_exec_stream_failure_invalidates_old_cached_sidecar(
+    tmp_path: Path,
+) -> None:
+    _write_modal_failure(
+        tmp_path,
+        "InternalError",
+        "Failed to read exec stdio stream: please contact support@modal.com",
+    )
+    (tmp_path / "trial_infra.json").write_text(
+        json.dumps(
+            {
+                "status": "ok",
+                "reason": "",
+                "version": SIDECAR_VERSION - 1,
+            }
+        )
+    )
+    verdict = classify_or_load(tmp_path)
+    assert verdict.status == "infra_failed"
+    assert verdict.evidence["failure_kind"] == "exec_stream"
+
+
+def test_retry_policy_includes_observed_modal_failures() -> None:
+    included = _build_retry_config().include_exceptions
+    assert included is not None
+    assert {"ConnectionError", "InternalError", "NotFoundError"} <= included
+
+
+def test_modal_sandbox_disappearance_is_infra(tmp_path: Path) -> None:
+    _write_modal_failure(
+        tmp_path,
+        "NotFoundError",
+        "Modal Sandbox with container ID ta-123 not found. "
+        "This means this Sandbox has already shut down.",
+    )
+    verdict = classify_trial(tmp_path)
+    assert verdict.status == "infra_failed"
+    assert verdict.reason == "modal_control_plane"
+    assert verdict.evidence["failure_kind"] == "sandbox_not_found"
+
+
+def test_modal_command_arg_limit_is_infra(tmp_path: Path) -> None:
+    _write_modal_failure(
+        tmp_path,
+        "InvalidError",
+        "Total length of CMD arguments cannot exceed 65536 bytes (ARG_MAX). "
+        "Got 79461 bytes.",
+    )
+    verdict = classify_trial(tmp_path)
+    assert verdict.status == "infra_failed"
+    assert verdict.reason == "harness_command_arg_limit"
+    assert verdict.evidence["failure_kind"] == "command_arg_limit"
+
+
+def test_modal_large_command_is_staged_outside_exec_argv() -> None:
+    class AsyncMethod:
+        def __init__(self, function):
+            self.aio = function
+
+    class FileHandle:
+        def __init__(self):
+            self.data = b""
+            self.write = AsyncMethod(self._write)
+
+        async def _write(self, data: bytes) -> None:
+            self.data += data
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+    class Process:
+        def __init__(self):
+            async def read_stdout():
+                return "ok"
+
+            async def read_stderr():
+                return ""
+
+            async def wait():
+                return 0
+
+            self.stdout = type("Stream", (), {"read": AsyncMethod(read_stdout)})()
+            self.stderr = type("Stream", (), {"read": AsyncMethod(read_stderr)})()
+            self.wait = AsyncMethod(wait)
+
+    class Sandbox:
+        def __init__(self):
+            self.open = AsyncMethod(self._open)
+            self.exec = AsyncMethod(self._exec)
+            self.opened: list[tuple[str, str, FileHandle]] = []
+            self.exec_calls: list[tuple[tuple[str, ...], dict]] = []
+
+        async def _open(self, path: str, mode: str) -> FileHandle:
+            handle = FileHandle()
+            self.opened.append((path, mode, handle))
+            return handle
+
+        async def _exec(self, *args: str, **kwargs) -> Process:
+            self.exec_calls.append((args, kwargs))
+            return Process()
+
+    sandbox = Sandbox()
+    environment = object.__new__(ModalEnvironment)
+    environment._sandbox = sandbox
+    environment._persistent_env = {}
+    environment.logger = logging.getLogger("test-modal-large-command")
+
+    command = "x" * (_MAX_INLINE_COMMAND_BYTES + 1)
+    result = asyncio.run(environment.exec(command))
+
+    assert result.return_code == 0
+    assert len(sandbox.opened) == 1
+    staged_path, mode, handle = sandbox.opened[0]
+    assert staged_path.startswith("/tmp/harbor-exec-")
+    assert mode == "wb"
+    assert handle.data == command.encode()
+    assert sandbox.exec_calls[0][0] == ("bash", staged_path)
+
+
+def test_modal_trials_have_bounded_lifetime(tmp_path: Path) -> None:
+    task = tmp_path / "task"
+    task.mkdir()
+    config = build_trial_config(
+        task_dir=task,
+        action_model="anthropic/claude-opus-4-8",
+        user_model="gemini/gemini-3.1-pro-preview",
+        user_key="user-secret",
+        user_api_base=None,
+        agent_env={"ANTHROPIC_API_KEY": "agent-secret"},
+        trials_dir=tmp_path / "trials",
+        env_type="modal",
+        agent_timeout=4800,
+        user_context_chars=3000,
+        call_user_on_completion=True,
+    )
+    assert config.environment.kwargs["sandbox_timeout_secs"] == 7200
+    assert config.environment.kwargs["sandbox_idle_timeout_secs"] == 900


### PR DESCRIPTION
## Summary

- preserve router headers, effort, and deferred tool-search settings in Claude Code trials
- redact credential-bearing config fields from durable trial artifacts without changing live in-memory values
- give each Modal run an isolated app name, bound sandbox lifetime, and safe staging for commands above Modal's argv limit
- classify and retry observed Modal DNS, exec-stream, sandbox-loss, and oversized-command failures
- make Claude Code version and durable result directories configurable for detached runs

## Validation

- `PYTHONPATH=src:external/harbor/src uv run --frozen --with pytest --with pytest-asyncio pytest tests/test_eval_hardening.py -q` — 8 passed
- Ruff passes for the changed Harbor files and focused tests
- Existing `src/` files retain pre-existing Ruff findings outside this patch
